### PR TITLE
Change 'release' to 'released'

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,5 +114,5 @@ The website templates and assets included in this repository are released
 under the Creative Commons Share-alike license 4.0.
 https://creativecommons.org/licenses/by-sa/4.0/
 
-Any code in this repository is to be release under the MIT license.
+Any code in this repository is to be released under the MIT license.
 https://opensource.org/licenses/MIT


### PR DESCRIPTION
The following issue has been fixed. 

Fixes coala/coAST/issues/#76
The word 'release' has been changed to 'released'.

I have done all the tests and everything seems to be working fine.